### PR TITLE
Add XML schema and ensure valid XML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ python parser.py path/to/document.pdf
 
 The script converts the PDF to HTML and streams the resulting XML to stdout.
 Sample files are available in `test_files/` for experimentation.
+
+## XML Schema
+
+The generated XML begins with an XML declaration and is wrapped in a `<document-container>` root element that references the `caterpillar.xsd` schema located in the project root. Use this schema to validate the structure of the output document.

--- a/caterpillar.xsd
+++ b/caterpillar.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="document-container">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="article"/>
+      </xs:sequence>
+      <xs:anyAttribute processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="article">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="h1" type="xs:string"/>
+        <xs:element name="author" type="xs:string" minOccurs="0"/>
+        <xs:element name="date" type="xs:string" minOccurs="0"/>
+        <xs:element name="nav" maxOccurs="1"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="section" type="xs:anyType"/>
+          <xs:element name="aside" type="xs:anyType"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:anyAttribute processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/parser.py
+++ b/parser.py
@@ -143,17 +143,22 @@ Example of the resulting XML:
 		lm += gen(name="think", max_tokens=1024)
 		lm += special_token("</think>")
 
-		lm += gen(name="result")
+		lm += gen(name="article")
 
-	print(lm)
-	return lm['result']
+	return (
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<document-container xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+		"xsi:noNamespaceSchemaLocation=\"caterpillar.xsd\">\n"
+		f"{lm['article']}\n"
+		"</document-container>"
+	)
 
 def html(path: str, mime: Optional[str]):
 	document = converter(path)
 	html, images = document.html, document.images
 
-	print(_parse_html(html))
+	return _parse_html(html)
 
 
 if __name__ == "__main__":
-	html(sys.argv[1], "application/pdf")
+	print(html(sys.argv[1], "application/pdf"))


### PR DESCRIPTION
## Summary
- Define a `document-container` root element in the schema and nest the article within it
- Emit the XML declaration and container wrapper directly from the parser without duplicating `<article>` tags

## Testing
- `python -m py_compile parser.py chat_template.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbe42d5ed48326859c63bc30d10760